### PR TITLE
Add Caching Expiration (Time-To-Live) Validation

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -26,6 +26,7 @@ export const findContent = factory.createHandlers(
 
     const content = getKeyValue(id)
     if (content && validateCacheExpiration(content.cached_at)) {
+      console.log(`Cache hit for ID: ${id}; returning cached data.`)
       return c.json(JSON.parse(content.value))
     }
 
@@ -39,6 +40,7 @@ export const findContent = factory.createHandlers(
     if (!newData) return c.text("No data found", 404)
 
     try {
+      console.log(`Cache miss for ID: ${id}; setting new data.`)
       setKeyValue(id, JSON.stringify(newData))
     } catch (error) {
       console.error(`Error setting key "${id}":`, (error as Error).message)

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -26,7 +26,7 @@ export const findContent = factory.createHandlers(
 
     const content = getKeyValue(id)
     if (content && validateCacheExpiration(content.cached_at)) {
-      console.log(`Cache hit for ID: ${id}; returning cached data.`)
+      console.log(`--- HIT ${id}; returning cached data.`)
       return c.json(JSON.parse(content.value))
     }
 
@@ -40,7 +40,7 @@ export const findContent = factory.createHandlers(
     if (!newData) return c.text("No data found", 404)
 
     try {
-      console.log(`Cache miss for ID: ${id}; setting new data.`)
+      console.log(`--- MISS ${id}; setting new data.`)
       setKeyValue(id, JSON.stringify(newData))
     } catch (error) {
       console.error(`Error setting key "${id}":`, (error as Error).message)

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -5,7 +5,7 @@ import { Context } from "hono"
 import { clearKVStore, getKeyValue, setKeyValue } from "../libs/kv"
 import { getYouTubeContentData, isValidYouTubeVideoId } from "../libs/yt"
 
-const TTL = Number(process.env.TTL) || 60 * 60 * 24
+const TTL = Number(process.env.CACHE_TTL) || 60 * 60 * 24
 
 const validateCacheExpiration = (cachedAt: string): boolean => {
   const expirationTime = new Date(cachedAt).getTime() + TTL * 1000

--- a/src/libs/kv.ts
+++ b/src/libs/kv.ts
@@ -3,6 +3,7 @@ import Database from "bun:sqlite"
 interface KeyValue {
   key: string
   value: string
+  cached_at: string
 }
 
 const kv = new Database("kv_store.sqlite", { strict: true, create: true })
@@ -31,11 +32,11 @@ export function setKeyValue(key: string, value: string): void {
   }
 }
 
-export function getKeyValue(key: string): string | null {
+export function getKeyValue(key: string): { value: string; cached_at: string } | null {
   try {
     const stmt = kv.prepare("SELECT value, cached_at FROM kv_store WHERE key = @key")
     const result = stmt.get({ key }) as KeyValue | undefined
-    return result ? result.value : null
+    return result ? { value: result.value, cached_at: result.cached_at } : null
   } catch (error) {
     console.error(`Error getting key "${key}":`, (error as Error).message)
     return null


### PR DESCRIPTION
This PR enhances caching by introducing cache expiration support and timestamp tracking in the key-value store. It ensures only valid cached data is used and improves logging and maintainability.

## What's changed:

### `findContent` Caching Enhancements
* Added `TTL` constant (defaults to 24h) for cache expiration control.
* Implemented `validateCacheExpiration` to check data freshness.
* Improved logging of cache hits/misses.
* Ensured expired data is not returned; new data is cached with updated timestamps.

### Key-Value Store Updates
* Extended `KeyValue` interface to include a `cached_at` timestamp.
* `initKVStore` now adds the `cached_at` column and backfills timestamps.
* `setKeyValue` updates `cached_at` on every set.
* `getKeyValue` returns both `value` and `cached_at` for expiration validation.
